### PR TITLE
Add initarg validation on object initialization.

### DIFF
--- a/gobject/gobject.generating.lisp
+++ b/gobject/gobject.generating.lisp
@@ -223,8 +223,9 @@
            :allocation :gobject-property
            :prop-type ,(gobject-property-gtype property)
            :accessor ,(property-accessor property)
-           :initarg ,(intern (string-upcase (property-name property))
-                             (find-package :keyword))
+           ,@(when (not (null (gobject-property-writable property)))
+               `(:initarg ,(intern (string-upcase (property-name property))
+                                   (find-package :keyword))))
            :prop-name ,(gobject-property-gname property)))
         ((cffi-property-p property)
          `(,(property-name property)

--- a/gobject/gobject.gobject-class.lisp
+++ b/gobject/gobject.gobject-class.lisp
@@ -125,9 +125,13 @@
   (iter (with slots = (class-slots class))
         (for (arg-name arg-value) on initargs by #'cddr)
         (for slot = (find arg-name slots :key #'slot-definition-initargs
-                                         :test 'member))
-        (unless (and slot (typep slot 'gobject-effective-slot-definition))
-          (nconcing (list arg-name arg-value)))))
+                                         :test #'member))
+        (typecase slot
+          (null (error 'property-unwritable-error
+                       :property-name arg-name
+                       :class-name (class-name class)))
+          (gobject-effective-slot-definition nil)
+          (t (nconcing (list arg-name arg-value))))))
 
 ;; Check if BASE-CLASS or a subclass of BASE-CLASS is on the list of
 ;; direct superclasses of INITARGS. This is not true for an interface


### PR DESCRIPTION
Without this change, it was possible to initialize a gobject with inexistent or non-writable properties.

E.g.

(make-instance 'gtk:window :foo t)
(make-instance 'gtk:window :is-active t)


------

@crategus I ran the tests for the library itself (`cl-cffi-glib`) and for those that depends on it (namely `cl-cffi-cairo` `cl-cffi-gdk-pixbuf` `cl-cffi-gtk4` `cl-cffi-pango`). 

The test suites ran successfully, but I was limited by #10 and https://github.com/crategus/cl-cffi-gtk4/issues/8.

