### PR TITLE
Fix async-ready-callback.

### DIFF
--- a/gio/gio.async-result.lisp
+++ b/gio/gio.async-result.lisp
@@ -161,9 +161,8 @@ int main (int argc, void *argv[])
      (data :pointer))
   (let ((func (glib:get-stable-pointer-value data)))
     (declare (type function func))
-    (unwind-protect
-      (funcall func source result))
-      (glib:free-stable-pointer data)))
+    (unwind-protect (funcall func source result)
+      (glib:free-stable-pointer data))))
 
 #+liber-documentation
 (setf (liber:alias-for-symbol 'async-ready-callback)


### PR DESCRIPTION
@crategus note that the call to free the pointer was outside the `unwind-protect`. It seems that you introduced it by mistake in commit 6fd7a7121c9e090e5decc00029dab2e06199a60c.